### PR TITLE
MAINT: stats: suggestions for "Add location and sign to KS test result"

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -7632,15 +7632,14 @@ def ks_1samp(x, cdf, args=(), alternative='two-sided', method='auto'):
         An object containing attributes:
 
         statistic : float
-            KS test statistic, either D, D+ or D- (depending on the value
-            of 'alternative')
+            KS test statistic, either D+, D-, or D (the maximum of the two)
         pvalue : float
             One-tailed or two-tailed p-value.
         statistic_location: float
-            Value of `x` corresponding with the KS statistic; i.e., the 
+            Value of `x` corresponding with the KS statistic; i.e., the
             distance between the hypothesized cumulative distribution function
-            and the empirical distribution function is greatest at this
-            location.
+            and the empirical distribution function is measured at this
+            observation.
         statistic_sign: str
             1 if the KS statistic is the maximal positive difference between
             empirical and hypothesized distributions (D+), -1 if the KS
@@ -7967,10 +7966,10 @@ def ks_2samp(data1, data2, alternative='two-sided', method='auto'):
         statistic_location: float
             Value from `data1` or `data2` corresponding with the KS statistic;
             i.e., the distance between the empirical distribution functions is
-            greatest at this observation.
+            measured at this observation.
         statistic_sign: int
             +1 if the empirical distribution function of `data1` exceeds
-            the empircal distribution function of `data2` at 
+            the empirical distribution function of `data2` at
             `statistic_location`, otherwise -1.
 
     See Also
@@ -8244,14 +8243,15 @@ def kstest(rvs, cdf, args=(), N=20, alternative='two-sided', method='auto'):
         An object containing attributes:
 
         statistic : float
-            KS test statistic, either D, D+ or D-.
+            KS test statistic, either D+, D-, or D (the maximum of the two)
         pvalue : float
             One-tailed or two-tailed p-value.
-
         statistic_location: float
-            Value of the stochastic variable closest to the KS statistic. By
-            definition, the distance between the two sampled distributions at
-            this value is largest.
+            Value of `x` corresponding with the KS statistic; i.e. the
+            observation at which the difference between CDFs is measured.
+        statistic_sign: int
+            1 if the KS statistic is the maximal positive difference between
+            CDFs (D+), -1 if the KS statistic is the negative difference (D-).
 
     See Also
     --------


### PR DESCRIPTION
#### Reference issue
scipy/scipy#17062

#### What does this implement/fix?
PEP8 fixes, additional documentation clarifications, and test suggestion.

#### Additional information
Did you intend for `statistic_location` to be the value of the _argument_ to the CDF function at which the difference between the CDFs is measured? That would correspond with `ks_2samp`, but it's not that. It is the _value_ of the theoretical CDF at which the difference between the CDFs is measured.
